### PR TITLE
changed arch linux link from gentoo to arch linux

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@ $ sudo apt-get install mosh</pre></p>
 	    </td>
 
 	    <td>
-	      <h3 class="callout"><a href="http://www.gentoo.org"><img class="logo" src="arch.png"></a> Arch Linux</h3>
+	      <h3 class="callout"><a href="http://www.archlinux.org"><img class="logo" src="arch.png"></a> Arch Linux</h3>
 	    </td>
 
 	    <td>


### PR DESCRIPTION
Noticed the arch linux link pointed to the wrong place.
