### PR TITLE
Fixes to installation instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,8 +209,8 @@
             <p><pre>$ sudo yum install mosh</pre></p>
 	  </div>
 
-          <div class="span4" style="vertical-align: top;">
-	    <h3 class="callout"><a href="http://www.ubuntu.com"><img class="logo" src="ubuntu.png"></a>Ubuntu <small>10.04 LTS or later</small></h3>
+          <div class="span4" sytle="vertical-align: top;">
+	    <h3 class="callout"><a href="http://www.ubuntu.com"><img class="logo" src="ubuntu.png"></a>Ubuntu <small>10.04 LTS thru 11.10</small></h3>
             <p>Available in the <a href="https://help.ubuntu.com/community/UbuntuBackports">backports repository</a> as <tt>mosh</tt>, or:
             <pre>$ sudo add-apt-repository ppa:keithw/mosh
 $ sudo apt-get update


### PR DESCRIPTION
Use divs so that install instruction section reflows if the browser is narrow, and change vertical alignment for clarity.

Correct the instructions for Arch, fixing mosh issue #162.

Clarify old Ubuntu versions.
