### PR TITLE
Use protocol-relative URLs for mosh downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,7 +263,7 @@ $ sudo apt-get install mosh</pre><p></p>
 	<div class="row">
           <div class="span4" style="vertical-align: top;">
 	    <h3 class="callout"><a href="http://www.apple.com"><img class="logo" src="macosx.png" alt=""></a>OS X <small>10.6 or later</small></h3>
-            <p></p><div class="prelike">Install <a href="http://mosh.mit.edu/mosh-1.2.4.pkg"><img src="dmg.png" alt=""> mosh-1.2.4.pkg</a>.</div><p></p>
+            <p></p><div class="prelike">Install <a href="//mosh.mit.edu/mosh-1.2.4.pkg"><img src="dmg.png" alt=""> mosh-1.2.4.pkg</a>.</div><p></p>
             <br />
 	  </div>
 
@@ -303,7 +303,7 @@ only. The vendors shown aren't affiliated with and haven't endorsed Mosh.</small
 	  <div class="span3">
 	    <h3 class="callout">Latest release</h3><br>
 	    <p>Extract
-              <a href="http://mosh.mit.edu/mosh-1.2.4.tar.gz">mosh-1.2.4.tar.gz</a>,
+              <a href="//mosh.mit.edu/mosh-1.2.4.tar.gz">mosh-1.2.4.tar.gz</a>,
               then</p>
 <pre>$ cd mosh-1.2.4
 $ ./configure


### PR DESCRIPTION
Now that there's an SSL certificate, don't force downloads over HTTP,
instead use the same protocol as the user is visiting the site with.
