### PR TITLE
Added small note that mosh needs to be installed on both the client and server

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,6 +196,7 @@ packet loss) helps Iain Learmonth <a href="http://gopher.floodgap.com/gopher/gw.
 <section id="getting">
   <div class="page-header">
     <h1>Getting Mosh</h1>
+    <small>The Mosh package should be installed on both the client and server.  Find your platform below for installation instructions.</small>
   </div>
 
   <div id="binaries" class="row-fluid">


### PR DESCRIPTION
It occasionally comes up in #mosh that people are unsure if mosh needs to be installed on the server.  I've added a small bit of text which should hopefully clear this up.  

Here is a screenshot of the rendered change:

![Screenshot](http://i.imgur.com/KIoGfF0.png)
