### PR TITLE
 Update installation instructions for Ubuntu.

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@ packet loss) helps Iain Learmonth <a href="http://gopher.floodgap.com/gopher/gw.
     <div class="span4" style="vertical-align: top;">
       <h3 class="callout"><a href="http://www.ubuntu.com"><img class="logo" src="ubuntu.png" alt=""></a>Ubuntu <small>13.04 and later</small></h3>
             <pre>$ sudo apt-get install mosh<pre>
-            <p><small>Ubuntu (piror to 13.04) includes an older versions of mosh in the universe repository (12.04 and later) and backports repository (10.04&ndash;11.10).You can run the following commands to install new version of mosh:</small></p>
+            <p><small>Ubuntu (prior to 13.04) includes an older versions of mosh in the universe repository (12.04 and later) and backports repository (10.04&ndash;11.10).You can run the following commands to install new version of mosh:</small></p>
             <pre>$ sudo apt-get install python-software-properties
 $ sudo add-apt-repository ppa:keithw/mosh
 $ sudo apt-get update

--- a/index.html
+++ b/index.html
@@ -202,12 +202,13 @@ packet loss) helps Iain Learmonth <a href="http://gopher.floodgap.com/gopher/gw.
 
   <div id="binaries" class="row-fluid">
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.ubuntu.com"><img class="logo" src="ubuntu.png" alt=""></a>Ubuntu <small>10.04 and later</small></h3>
+      <h3 class="callout"><a href="http://www.ubuntu.com"><img class="logo" src="ubuntu.png" alt=""></a>Ubuntu <small>13.04 and later</small></h3>
+            <pre>$ sudo apt-get install mosh<pre>
+            <p><small>Ubuntu (piror to 13.04) includes an older versions of mosh in the universe repository (12.04 and later) and backports repository (10.04&ndash;11.10).You can run the following commands to install new version of mosh:</small></p>
             <pre>$ sudo apt-get install python-software-properties
 $ sudo add-apt-repository ppa:keithw/mosh
 $ sudo apt-get update
 $ sudo apt-get install mosh</pre>
-            <p><small>Ubuntu also includes older versions of mosh in the universe repository (12.04 and later) and backports repository (10.04&ndash;11.10).</small></p>
             <br />
     </div>
 


### PR DESCRIPTION
Ubunutu 13.04+ now has 1.2.4a in its repository, thus I updated the installation instructions.