### PR TITLE
Adds software-properties-common to Ubuntu installation

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
   </div>
   </div>
 </section>
-      
+
 <section id="news">
   <div class="page-header">
     <h1>Recent News</h1>
@@ -203,11 +203,11 @@ packet loss) helps Iain Learmonth <a href="http://gopher.floodgap.com/gopher/gw.
   <div id="binaries" class="row-fluid">
     <div class="span4" style="vertical-align: top;">
       <h3 class="callout"><a href="http://www.ubuntu.com"><img class="logo" src="ubuntu.png" alt=""></a>Ubuntu <small>10.04 and later</small></h3>
-            <pre>$ sudo apt-get install python-software-properties
+            <pre>$ sudo apt-get install software-properties-common
 $ sudo add-apt-repository ppa:keithw/mosh
 $ sudo apt-get update
 $ sudo apt-get install mosh</pre>
-            <p><small>Ubuntu also includes older versions of mosh in the universe repository (12.04 and later) and backports repository (10.04&ndash;11.10).</small></p>
+            <p><small>Install <code>python-software-properties</code> instead on Ubuntu 10.04 - 12.04. Ubuntu also includes older versions of mosh in the universe repository (12.04 and later) and backports repository (10.04&ndash;11.10).</small></p>
             <br />
     </div>
 
@@ -466,7 +466,7 @@ $ make
   <div class="page-header">
     <h1>Technical Info</h1>
   </div>
-  
+
 
   <h2 class="callout">Mosh at USENIX ATC</h2>
 
@@ -936,7 +936,7 @@ remote servers "feel" more like the local machine!</p>
   <p>1. Log in to the remote host, and run <code>mosh-server</code>.</p>
 
   <p>It will give output like:</p>
-<pre>$ mosh-server 
+<pre>$ mosh-server
 
 MOSH CONNECT <b>60004</b> <b>4NeCCgvZFe2RnPgrcU1PQw</b>
 
@@ -1024,7 +1024,7 @@ server's IP address with "host remotehost".</p>
   <div class="page-header">
     <h1>Contact</h1>
   </div>
-  
+
   <div class="row">
   <div class="span8">
   <ul>


### PR DESCRIPTION
Ubuntu Server 12.04+ puts `add-apt-repository` in this package instead, apparently.