### PR TITLE
Redo Cygwin install text.

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,8 +269,9 @@ packet loss) helps Iain Learmonth <a href="elevator.txt">escape from an elevator
   <div class="row">
     <div class="span4" style="vertical-align: top;">
       <h3 class="callout"><a href="http://www.cygwin.com"><img class="logo" src="Cygwin_logo.svg" width="50" height="50" alt=""></a>Cygwin</h3>
-      <div class="prelike">Install the <a href="http://cygwin.com/install.html">Cygwin package</a> from the Cygwin setup.exe.</div>
-      <br />
+      <pre>C:\&gt; setup.exe -q mobile-shell</pre>
+      <p><small>Mosh on Cygwin uses OpenSSH and is suitable for Windows users with advanced SSH configurations.</small></p>
+      <p><small>Mosh is not compatible with Cygwin's built-in Windows Console terminal emulation.  You will need to run Mosh from a full-featured terminal program such as mintty, rxvt, PuTTY, or an X11 terminal emulator.</small></p>
     </div>
 
     <div class="span4" style="vertical-align: top;">


### PR DESCRIPTION
New improved text explaining the strengths and flaws of Mosh on Cygwin.
Should pair nicely with #36.