### PR TITLE
Change many HTTP links to HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,21 +158,21 @@
   </div>
 
   <ul id="news-list">
-    <li><b>July 23, 2015</b>: <a href="http://mailman.mit.edu/pipermail/mosh-users/2015-July/000283.html">Mosh 1.2.5 released</a>, with John Hood as release lead. New features include support for mouse modes and a reconfigurable escape character, and initial support for IPv6.</li>
+    <li><b>July 23, 2015</b>: <a href="https://mailman.mit.edu/pipermail/mosh-users/2015-July/000283.html">Mosh 1.2.5 released</a>, with John Hood as release lead. New features include support for mouse modes and a reconfigurable escape character, and initial support for IPv6.</li>
     <li><b>May 31, 2015</b>: Another team of Stanford students has <a href="https://reproducingnetworkresearch.wordpress.com/2015/05/31/cs244-15-mosh-reproducing-network-research-results/">reproduced some of the Mosh research paper's results</a>.
     <li><b>January 20, 2014</b>: <a href="https://github.com/rpwoodbu/mosh-chrome/wiki">Mosh for Chrome</a>, which brings Mosh to the Chrome browser and Chrome OS, is released. It can be installed <a href="https://chrome.google.com/webstore/detail/mosh/ooiklbnjmhbcgemelgfhaeaocllobloj">here</a>.</li>
     <li><b>August 9, 2013</b>: <a href="https://play.google.com/store/apps/details?id=com.sonelli.juicessh">JuiceSSH</a> (SSH client for Android) adds official Mosh support &mdash; available on the <a href="https://play.google.com/store/apps/details?id=com.sonelli.juicessh">Play Store</a></li>
     <li><b>April 14, 2013</b>: Mosh has posted an <a href="https://docs.google.com/document/d/10o-TLA03bY4cZzEIZR-5wKmBecvYKpOEFRqSJFbIm3M/edit?usp=sharing">Ideas List</a> for interested contributors!</li>
     <li><b>March 27,
-    2013</b>: <a href="http://mailman.mit.edu/pipermail/mosh-users/2013-March/000167.html">Mosh
+    2013</b>: <a href="https://mailman.mit.edu/pipermail/mosh-users/2013-March/000167.html">Mosh
     1.2.4 has been released</a>. Changes largely include bug
     fixes, improved robustness, and added platform support (now
     on AIX and stock Solaris!). This version will be in Ubuntu
     13.04 (raring).</li>
     <li><b>March 24, 2013</b>: The <a href="https://twitter.com/zacchiro/status/315893796695064576">Debian Project Leader switches to Mosh</a>. Welcome, Stefano! We're proud to have you.</li>
     <li><b>March 14, 2013</b>: Two teams of Stanford students have
-    reproduced parts of the <a href="http://mosh.mit.edu/mosh-paper.pdf">Mosh research paper</a> on Stanford's
-    <a href="http://reproducingnetworkresearch.wordpress.com">Reproducing Network Research blog</a>. Kanthi Nagaraj and Emily McMilin <a href="http://reproducingnetworkresearch.wordpress.com/2013/03/14/mosh-cs244-13/">tested SSP's resilience to packet loss</a>, and Ahmed Aljunied and Anand Atreya <a href="http://reproducingnetworkresearch.wordpress.com/2013/03/13/cs244-2013-evaluation-of-mosh-mobile-shell-performance-results/">evaluated Mosh's predictive local echo</a>.
+    reproduced parts of the <a href="https://mosh.mit.edu/mosh-paper.pdf">Mosh research paper</a> on Stanford's
+    <a href="https://reproducingnetworkresearch.wordpress.com">Reproducing Network Research blog</a>. Kanthi Nagaraj and Emily McMilin <a href="https://reproducingnetworkresearch.wordpress.com/2013/03/14/mosh-cs244-13/">tested SSP's resilience to packet loss</a>, and Ahmed Aljunied and Anand Atreya <a href="https://reproducingnetworkresearch.wordpress.com/2013/03/13/cs244-2013-evaluation-of-mosh-mobile-shell-performance-results/">evaluated Mosh's predictive local echo</a>.
     <li><b>March 12, 2013</b>: Mosh celebrates its first anniversary of
 1.0. Hard to believe it's already been a year. We could not have done
 it without the hard work of many of you, especially Hari Balakrishnan,
@@ -186,7 +186,7 @@ Juhani Lindfors, Timo Sirainen, Ira Cooper, Felix Gröbert, Luke
 Mewburn, Anton Lundin, Kevin Ballard, and Axel Beckert!</li>
     <li><b>November 2012</b>: Mosh on the cover of <a href="http://www.linux-magazine.com/Issues/2012/144/Mosh-and-AutoSSH">Linux Magazine</a>.
     <li><b>Oct. 19,
-    2012</b>: <a href="http://mailman.mit.edu/pipermail/mosh-users/2012-October/000152.html">Mosh
+    2012</b>: <a href="https://mailman.mit.edu/pipermail/mosh-users/2012-October/000152.html">Mosh
     1.2.3 has been released</a>. Changes include more resilience to
 evil NATs, power savings for mobile clients, switching to OpenSSL's AES
 implementation, and a licensing exception to allow Mosh on Apple's app store.
@@ -207,7 +207,7 @@ packet loss) helps Iain Learmonth <a href="elevator.txt">escape from an elevator
   <!-- OSX / Darwin -->
   <div class="row">
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.apple.com"><img class="logo" src="macosx.png" alt=""></a>OS X <small>10.5 or later</small></h3>
+      <h3 class="callout"><a href="https://www.apple.com"><img class="logo" src="macosx.png" alt=""></a>OS X <small>10.5 or later</small></h3>
       <div class="prelike">OS X 10.9 or later: <a href="https://mosh.mit.edu/mosh-1.2.5.pkg"><img src="dmg.png" alt=""> mosh-1.2.5.pkg</a>.</div>
       <br />
       <div class="prelike">OS X 10.5&ndash;10.9: <a href="https://mosh.mit.edu/mosh-1.2.5-leopard.pkg"><img src="dmg.png" alt=""> mosh-1.2.5-leopard.pkg</a>.</div>
@@ -215,12 +215,12 @@ packet loss) helps Iain Learmonth <a href="elevator.txt">escape from an elevator
     </div>
 
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://mxcl.github.com/homebrew/"><img class="logo" src="homebrew2.png" alt=""></a>Homebrew <small>OS X 10.5 or later</small></h3>
+      <h3 class="callout"><a href="https://mxcl.github.io/homebrew/"><img class="logo" src="homebrew2.png" alt=""></a>Homebrew <small>OS X 10.5 or later</small></h3>
             <pre>$ brew install mobile-shell</pre>
       <br />
     </div>
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.macports.org"><img class="logo" src="macports.png" alt=""></a>MacPorts <small>OS X 10.5 or later</small></h3>
+      <h3 class="callout"><a href="https://www.macports.org"><img class="logo" src="macports.png" alt=""></a>MacPorts <small>OS X 10.5 or later</small></h3>
             <pre>$ sudo port install mosh</pre>
       <br />
     </div>
@@ -239,7 +239,7 @@ packet loss) helps Iain Learmonth <a href="elevator.txt">escape from an elevator
     </div>
   
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.cygwin.com"><img class="logo" src="Cygwin_logo.svg" width="50" height="50" alt=""></a>Cygwin</h3>
+      <h3 class="callout"><a href="https://www.cygwin.com"><img class="logo" src="Cygwin_logo.svg" width="50" height="50" alt=""></a>Cygwin</h3>
       <pre>C:\&gt; setup.exe -q mobile-shell</pre>
       <p><small>Mosh on Cygwin uses OpenSSH and is suitable for Windows users with advanced SSH configurations.
 	  <br />
@@ -250,7 +250,7 @@ packet loss) helps Iain Learmonth <a href="elevator.txt">escape from an elevator
   <!-- Google / Mobile platforms -->
   <div class="row">
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.android.com/"><img class="logo" src="Android_Robot_100.png" alt=""></a>Android</h3>
+      <h3 class="callout"><a href="https://www.android.com/"><img class="logo" src="Android_Robot_100.png" alt=""></a>Android</h3>
       <div class="prelike">
         <img src="JuiceSSH.png" alt="" style="height: 24px; width: 24px; display:inline-block; vertical-align:middle">
         &nbsp;
@@ -258,12 +258,12 @@ packet loss) helps Iain Learmonth <a href="elevator.txt">escape from an elevator
         <br /><br />
         or...<br />
         <br />
-        Install the <a href="http://dan.drown.org/android/mosh/">port by Daniel Drown</a>, built on Irssi ConnectBot.</div>
+        Install the <a href="https://dan.drown.org/android/mosh/">port by Daniel Drown</a>, built on Irssi ConnectBot.</div>
       <br />
     </div>
 
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.google.com/chrome"><img class="logo" src="chrome.png" alt=""></a>Chrome / Chrome OS</h3>
+      <h3 class="callout"><a href="https://www.google.com/chrome"><img class="logo" src="chrome.png" alt=""></a>Chrome / Chrome OS</h3>
       <div class="prelike">
         <img src="mosh-chrome.png" alt="" style="height: 24px; width: 24px; display:inline-block; vertical-align:middle">
         &nbsp;
@@ -275,35 +275,35 @@ packet loss) helps Iain Learmonth <a href="elevator.txt">escape from an elevator
   <!-- Linux -->
   <div class="row">
     <div class="span4" style="vertical-align: top;">
-        <h3 class="callout"><a href="http://www.alpinelinux.org"><img class="logo" src="alpinelinux-logo.png" alt=""></a>Alpine Linux</h3>
+        <h3 class="callout"><a href="https://alpinelinux.org"><img class="logo" src="alpinelinux-logo.png" alt=""></a>Alpine Linux</h3>
       <pre># apk add mosh</pre>
         <br />
     </div>
 
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.archlinux.org"><img class="logo" src="arch.png" alt=""></a> Arch Linux</h3>
+      <h3 class="callout"><a href="https://www.archlinux.org"><img class="logo" src="arch.png" alt=""></a> Arch Linux</h3>
             <pre># pacman -S mosh</pre>
       <br />
     </div>
 
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.debian.org"><img class="logo" src="debian.png" alt=""></a>Debian <small>squeeze-backports and later</small><br /></h3>
+      <h3 class="callout"><a href="https://www.debian.org"><img class="logo" src="debian.png" alt=""></a>Debian <small>squeeze-backports and later</small><br /></h3>
             <pre>$ sudo apt-get install mosh</pre>
     </div>
   </div>
   <div class="row">
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.fedoraproject.org"><img class="logo" src="fedora.png" alt=""></a>Fedora <small>15 or later</small></h3>
+      <h3 class="callout"><a href="https://getfedora.org"><img class="logo" src="fedora.png" alt=""></a>Fedora <small>15 or later</small></h3>
             <pre>$ sudo yum install mosh</pre>
     </div>
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.gentoo.org"><img class="logo" src="gentoo.png" alt=""></a> Gentoo</h3>
+      <h3 class="callout"><a href="https://www.gentoo.org"><img class="logo" src="gentoo.png" alt=""></a> Gentoo</h3>
             <pre># emerge net-misc/mosh</pre>
       <br />
     </div>
 
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.opensuse.org"><img class="logo" src="openSUSE.png" alt=""></a> openSUSE <small>12.3 or later</small></h3>
+      <h3 class="callout"><a href="https://www.opensuse.org"><img class="logo" src="openSUSE.png" alt=""></a> openSUSE <small>12.3 or later</small></h3>
             <pre>$ sudo zypper in mosh</pre>
       <br />
     </div>
@@ -321,19 +321,19 @@ packet loss) helps Iain Learmonth <a href="elevator.txt">escape from an elevator
   <!-- *BSD -->
   <div class="row">
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.freebsd.org"><img class="logo" src="freebsd.png" alt=""></a> FreeBSD</h3>
+      <h3 class="callout"><a href="https://www.freebsd.org"><img class="logo" src="freebsd.png" alt=""></a> FreeBSD</h3>
             <pre># pkg install net/mosh</pre>
       <br />
     </div>
 
     <div class="span4" style="vertical-align: top;">
-        <h3 class="callout"><a href="http://www.openbsd.org"><img class="logo" src="ppuf100X91.gif" alt=""></a>OpenBSD</h3>
+        <h3 class="callout"><a href="https://www.openbsd.org"><img class="logo" src="ppuf100X91.gif" alt=""></a>OpenBSD</h3>
       <pre># pkg_add mosh</pre>
         <br />
     </div>
 
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.netbsd.org"><img class="logo" src="NetBSD-smaller-tb.png" alt=""></a>NetBSD <small>(pkgsrc)</small></h3>
+      <h3 class="callout"><a href="https://www.netbsd.org"><img class="logo" src="NetBSD-smaller-tb.png" alt=""></a>NetBSD <small>(pkgsrc)</small></h3>
       <pre># cd net/mosh; make install clean</pre>
     </div>
   </div>
@@ -341,7 +341,7 @@ packet loss) helps Iain Learmonth <a href="elevator.txt">escape from an elevator
   <!-- Other UNIXes -->
   <div class="row">
     <div class="span4" style="vertical-align: top;">
-      <h3 class="callout"><a href="http://www.opencsw.org"><img class="logo" src="opencsw.png" alt=""></a>OpenCSW <small>Solaris 10 Update 8 or later</small></h3>
+      <h3 class="callout"><a href="https://www.opencsw.org"><img class="logo" src="opencsw.png" alt=""></a>OpenCSW <small>Solaris 10 Update 8 or later</small></h3>
       <pre># pkgutil -i mosh</pre>
       <br />
     </div>
@@ -380,7 +380,7 @@ $ make
           <h3 class="callout">Dependencies</h3><br>
           <table class="table table-striped" style="width: 100%;">
                   <thead><tr><th>Name</th><th>Typical package</th></tr></thead>
-                  <tr class="deps"><td><a href="http://code.google.com/p/protobuf/">Protocol Buffers</a></td><td>protobuf-compiler, libprotobuf-dev</td></tr>
+                  <tr class="deps"><td><a href="https://github.com/google/protobuf">Protocol Buffers</a></td><td>protobuf-compiler, libprotobuf-dev</td></tr>
                   <tr><td>ncurses</td><td>libncurses5-dev</td></tr>
                   <tr><td>zlib</td><td>zlib1g-dev</td></tr>
                   <tr><td>utempter (optional)</td><td>libutempter-dev</td></tr>
@@ -608,7 +608,7 @@ $ make
   <dt>ISO 2022 locking escapes</dt>
 
   <dd><p>Only Mosh will never get stuck in hieroglyphs when a nasty program writes to the terminal. (See Markus Kuhn's discussion of the relationship between
-<a href="http://www.cl.cam.ac.uk/~mgk25/unicode.html#term">ISO 2022 and UTF-8</a>.)</p>
+<a href="https://www.cl.cam.ac.uk/~mgk25/unicode.html#term">ISO 2022 and UTF-8</a>.)</p>
 
     <div class="thumbs">
       <div class="row">
@@ -660,7 +660,7 @@ menu.</small></p>
     needs to be able to delete a typed multibyte character
     sequence from an input buffer.  On OS X and Linux, this is
     done with the "IUTF8" termios flag.)
-    (See <a href="http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=665757">diagnostic
+    (See <a href="https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=665757">diagnostic
         explaining the need for this flag.</a>)</p>
 
     <p>Mosh sets the IUTF8 flag when possible and stubbornly refuses to start up unless the user has a
@@ -897,8 +897,8 @@ remote servers "feel" more like the local machine!</p>
         1.3 will have complete scrollback support; see <a
         href="https://github.com/keithw/mosh/issues/2">this issue</a> and the
         others which are linked from there.  For now, the workaround is to use
-        <a href="http://www.gnu.org/software/screen/">screen</a> or <a
-        href="http://tmux.sourceforge.net/">tmux</a> on the remote side.</p></dd>
+        <a href="https://www.gnu.org/software/screen/">screen</a> or <a
+        href="https://github.com/tmux/tmux">tmux</a> on the remote side.</p></dd>
 
   <dt>Q: How do I get 256 colors?</dt>
 
@@ -1029,7 +1029,7 @@ server's IP address with "host remotehost".</p>
 
   <dt>Q: How do I contribute to mosh?</dt>
 
-  <dd><p>We welcome your contribution! Please join us in <code>#mosh</code> channel on <a href="http://freenode.net/">Freenode</a> IRC, <a href="https://github.com/mobile-shell/mosh">visit us on GitHub</a>,
+  <dd><p>We welcome your contribution! Please join us in <code>#mosh</code> channel on <a href="https://freenode.net/">Freenode</a> IRC, <a href="https://github.com/mobile-shell/mosh">visit us on GitHub</a>,
   or email <code>mosh-devel@mit.edu</code>.</p></dd>
 
   <dt>Q: Who helped with mosh?</dt>
@@ -1046,7 +1046,7 @@ server's IP address with "host remotehost".</p>
 
 <li>Nickolai Zeldovich for helpful comments on the Mosh research paper.
 
-<li>Richard Stallman for helpful discussion about the capabilities of the <a href="http://hdl.handle.net/1721.1/5694">SUPDUP Local Editing Protocol</a>.
+<li>Richard Stallman for helpful discussion about the capabilities of the <a href="https://dspace.mit.edu/handle/1721.1/5694">SUPDUP Local Editing Protocol</a>.
 
 <li>Nelson Elhage
 
@@ -1095,17 +1095,17 @@ server's IP address with "host remotehost".</p>
       <li><p><code>mosh-devel@mit.edu</code><br>
         Mosh development and discussion.
 
-        Sign up or view archives at <a href="http://mailman.mit.edu/mailman/listinfo/mosh-devel">http://mailman.mit.edu/mailman/listinfo/mosh-devel</a>.</p></li>
+        Sign up or view archives at <a href="https://mailman.mit.edu/mailman/listinfo/mosh-devel">https://mailman.mit.edu/mailman/listinfo/mosh-devel</a>.</p></li>
 
       <li><p><code>mosh-users@mit.edu</code><br>
         Mosh user discussion and site best practices.
 
-        Sign up or view archives at <a href="http://mailman.mit.edu/mailman/listinfo/mosh-users">http://mailman.mit.edu/mailman/listinfo/mosh-users</a>.</p></li>
+        Sign up or view archives at <a href="https://mailman.mit.edu/mailman/listinfo/mosh-users">https://mailman.mit.edu/mailman/listinfo/mosh-users</a>.</p></li>
 
-      <li><p><code>#mosh</code> channel on <a href="http://freenode.net/">Freenode</a> IRC<br>
+      <li><p><code>#mosh</code> channel on <a href="https://freenode.net/">Freenode</a> IRC<br>
 
               You can <a
-              href="http://webchat.freenode.net/?channels=mosh">connect with a
+              href="https://webchat.freenode.net/?channels=mosh">connect with a
               Web client</a>, try an <a
               href="irc://irc.freenode.net/mosh"><span style="font-family: monospace">irc://</span> URL</a>,
               or manually configure your client for <code>irc.freenode.net</code>.</p></li>


### PR DESCRIPTION
Change links to resources identified by URLs with the `http` scheme to
use equivalent HTTPS URLs, where the linked resources are available via
HTTPS.

This includes updating the Web addresses of e.g. protobuf and tmux,
which have moved to GitHub (and tmux's SourceForge page is no longer
available).