### PR TITLE
Mosh replaces ssh terminals, not ssh.

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
         <h2>(mobile shell)</h2>
         <p>Remote terminal application that
         allows <strong class="callout">roaming</strong>, supports <strong class="callout">intermittent connectivity</strong>, and provides intelligent <strong class="callout">local echo</strong> and line editing of user keystrokes.</p>
-        <p>Mosh is a replacement for SSH. It's more robust and responsive, especially over Wi-Fi, cellular, and long-distance links.</p>
+        <p>Mosh is a replacement for interactive SSH terminals. It's more robust and responsive, especially over Wi-Fi, cellular, and long-distance links.</p>
         <p>Mosh is free software, available for GNU/Linux, BSD, macOS, Solaris, Android, Chrome, and iOS.</p>
       </div>
       <div class="span5"><img src="mosh.png" style="max-width:120%;" alt="">


### PR DESCRIPTION
This small changes attempts to reduce confusion among new users who read
that "Mosh is a replacement for SSH" on the mosh.org homepage.  Strictly
speaking, this is not correct, as SSH does more than just remote
terminals, and mosh isn't a replacement for any of those things.

I also think we should create a FAQ entry about this.  Unless there are objections, I'll open a new PR with some proposed text to start the discussion