### PR TITLE
Switch travis CI to use java11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 
 install:
   - pip install --user html5validator


### PR DESCRIPTION
Java8 on the newer travis builders has known problems:
https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038