### PR TITLE
Update Termux store URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@ by the MIT <a href="https://sipb.mit.edu">Student Information Processing Board</
 
     <li><b>June 15, 2016</b>: <a href="https://github.com/blinksh/blink">Mosh for iOS (Blink)</a> has its first <a href="https://mailman.mit.edu/pipermail/mosh-devel/2016-June/001339.html">alpha release</a>.
 
-    <li><b>April 17, 2016</b>: <a href="https://play.google.com/store/apps/details?id=com.termux">Termux</a> (open source Linux environment for Android) adds a mosh 1.2.5 package.</li>
+    <li><b>April 17, 2016</b>: <a href="https://f-droid.org/en/packages/com.termux">Termux</a> (open source Linux environment for Android) adds a mosh 1.2.5 package.</li>
     <li><b>July 23, 2015</b>: <a href="https://mailman.mit.edu/pipermail/mosh-users/2015-July/000283.html">Mosh 1.2.5 released</a>, with John Hood as release lead. New features include support for mouse modes and a reconfigurable escape character, and initial support for IPv6.</li>
     <li><b>May 31, 2015</b>: Another team of Stanford students has <a href="https://reproducingnetworkresearch.wordpress.com/2015/05/31/cs244-15-mosh-reproducing-network-research-results/">reproduced some of the Mosh research paper's results</a>.
     <li><b>January 20, 2014</b>: <a href="https://github.com/rpwoodbu/mosh-chrome/wiki">Mosh for Chrome</a>, which brings Mosh to the Chrome browser and Chrome OS, is released. It can be installed <a href="https://chrome.google.com/webstore/detail/mosh/ooiklbnjmhbcgemelgfhaeaocllobloj">here</a>.</li>
@@ -294,7 +294,7 @@ packet loss) helps Iain Learmonth <a href="elevator.txt">escape from an elevator
         <br />
         <img src="assets/img/termux.png" alt="" style="height: 24px; width: 24px; display:inline-block; vertical-align:middle">
         &nbsp;
-        <a href="https://play.google.com/store/apps/details?id=com.termux">Install Termux from the Play Store</a></div>
+        <a href="https://f-droid.org/en/packages/com.termux">Install Termux from F-Droid</a></div>
       <br />
     </div>
 


### PR DESCRIPTION
Termux is no longer being updated on Google Play; F-Droid is now the official store to use.