### PR TITLE
Fix image and video overflow on mobile display

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -7,6 +7,25 @@ section {
   padding-top: 1.563rem;
 }
 
+img {
+  max-width: 100%;
+}
+
+.video-container {
+  position: relative;
+  padding-bottom: 56.25%;
+}
+
+.video-container iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  max-width: 560px;
+  max-height: 315px;
+}
+
 .hero-titles {
   padding-bottom: 5%;
 }

--- a/index.html
+++ b/index.html
@@ -585,8 +585,8 @@ in <a href="https://www.usenix.org/publications/login">USENIX
       </div>
     </div>
 
-    <div class="span8">
-      <iframe width="560" height="315" src="https://www.youtube.com/embed/XsIxNYl0oyU?rel=0" style="border: none" allowfullscreen></iframe>
+    <div class="span8 video-container">
+      <iframe src="https://www.youtube.com/embed/XsIxNYl0oyU?rel=0" style="border: none" allowfullscreen></iframe>
     </div>
   </div>
 


### PR DESCRIPTION
Currently, if you visit this website on mobile, the layout is broken due to images and the YouTube video overflow.
With this fix, I restricted the max-width of images and the iframe to 100% to prevent unwanted horizontal scroll.

Before|After
--|--
![Jun-28-2022 05-19-10](https://user-images.githubusercontent.com/17572067/176028519-1a4d6f75-5f30-4b23-9842-9fce8e318e3d.gif)|![Jun-28-2022 05-19-20](https://user-images.githubusercontent.com/17572067/176028508-b1600ef7-857a-444b-8924-83cd8d548577.gif)

Before|After
--|--
![image](https://user-images.githubusercontent.com/17572067/176026998-f72e9b52-ca1c-43b7-97e8-001e2fc3254e.png)|![image](https://user-images.githubusercontent.com/17572067/176026487-d3fb642e-1dfe-46f8-bc7d-cd2cc152e74f.png)
![image](https://user-images.githubusercontent.com/17572067/176027044-eb9ddfd3-65cc-471d-b302-612acc790e03.png)|![image](https://user-images.githubusercontent.com/17572067/176026532-82ea7dcf-1392-482d-a4a4-df2780fbe70f.png)
