### PR TITLE
Correct Cygwin package name

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,7 +274,7 @@ packet loss) helps Iain Learmonth <a href="elevator.txt">escape from an elevator
   
     <div class="span4" style="vertical-align: top;">
       <h3 class="callout"><a href="https://www.cygwin.com"><img class="logo" src="Cygwin_logo.svg" width="50" height="50" alt=""></a>Cygwin</h3>
-      <pre>C:\&gt; setup.exe -q mobile-shell</pre>
+      <pre>C:\&gt; setup.exe -q mosh</pre>
       <p><small>Mosh on Cygwin uses OpenSSH and is suitable for Windows users with advanced SSH configurations.
 	  <br />
 	  Mosh is not compatible with Cygwin's built-in Windows Console terminal emulation.  You will need to run Mosh from a full-featured terminal program such as mintty, rxvt, PuTTY, or an X11 terminal emulator.</small></p>


### PR DESCRIPTION
Cygwin mosh package is now "mosh", not "mobile-shell"