### PR TITLE
fix cygwin installation instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,7 +277,7 @@ packet loss) helps Iain Learmonth <a href="elevator.txt">escape from an elevator
   
     <div class="span4" style="vertical-align: top;">
       <h3 class="callout"><a href="https://www.cygwin.com"><img class="logo" src="Cygwin_logo.svg" width="50" height="50" alt=""></a>Cygwin</h3>
-      <pre>C:\&gt; setup.exe -q mosh</pre>
+      <pre>C:\&gt; c:\cygwin64\cygwinsetup.exe -qP mosh</pre>
       <p><small>Mosh on Cygwin uses OpenSSH and is suitable for Windows users with advanced SSH configurations.
 	  <br />
 	  Mosh is not compatible with Cygwin's built-in Windows Console terminal emulation.  You will need to run Mosh from a full-featured terminal program such as mintty, rxvt, PuTTY, or an X11 terminal emulator.</small></p>


### PR DESCRIPTION
I'm not sure if the original command was for an older cygwin setup, but the `-q` flag presently just means a quiet install, but it ignores the `mosh` arg without specifying `-P` to install a named package.

Cygwinsetup is also installed in c:\cygwin64\cygwinsetup.exe by default, so let's fix that path/name.